### PR TITLE
fix(helm): Add `/tmp` volume and volumeMount to tools deployment

### DIFF
--- a/helm/kagent-tools/templates/deployment.yaml
+++ b/helm/kagent-tools/templates/deployment.yaml
@@ -111,4 +111,9 @@ spec:
               port: http-tools
             initialDelaySeconds: 15
             periodSeconds: 15
-
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
Mount an emptyDir volume at `/tmp` in the kagent-tools container so temporary file writes (used by kubectl apply/create operations) succeed when readOnlyRootFilesystem: true is set on the pod security context.