### PR TITLE
fix: pass prometheus and grafana config as env vars in helm chart

### DIFF
--- a/helm/kagent-tools/templates/deployment.yaml
+++ b/helm/kagent-tools/templates/deployment.yaml
@@ -48,7 +48,6 @@ spec:
       {{- end }}
       {{- end }}
 
-
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "kagent-tools.serviceAccountName" . }}
@@ -84,7 +83,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "kagent-tools.fullname" . }}-openai
                   key: OPENAI_API_KEY
-                  optional: true # if the secret is not found, the tool will not be available
+                  optional: true
             - name: OTEL_TRACING_ENABLED
               value: {{ .Values.otel.tracing.enabled | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -95,6 +94,16 @@ spec:
               value: {{ .Values.otel.tracing.exporter.otlp.insecure | quote }}
             - name: TOKEN_PASSTHROUGH
               value: {{ (index .Values.tools "k8s" | default dict).tokenPassthrough | default false | quote }}
+            - name: PROMETHEUS_URL
+              value: {{ .Values.tools.prometheus.url | quote }}
+            - name: PROMETHEUS_USERNAME
+              value: {{ .Values.tools.prometheus.username | quote }}
+            - name: PROMETHEUS_PASSWORD
+              value: {{ .Values.tools.prometheus.password | quote }}
+            - name: GRAFANA_URL
+              value: {{ .Values.tools.grafana.url | quote }}
+            - name: GRAFANA_API_KEY
+              value: {{ .Values.tools.grafana.apiKey | quote }}
           {{- with .Values.tools.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
## Problem
`tools.prometheus.url`, `tools.prometheus.username`, `tools.prometheus.password`, 
`tools.grafana.url` and `tools.grafana.apiKey` values were defined in `values.yaml` 
but never passed to the container as environment variables in `deployment.yaml`.

## Solution
Added the missing environment variables to the deployment template so that 
Prometheus and Grafana configuration is properly passed to the tool server.

Fixes #36