### PR TITLE
feat(helm): add extraVolumes/extraVolumeMounts to the tools deployment

### DIFF
--- a/helm/kagent-tools/templates/deployment.yaml
+++ b/helm/kagent-tools/templates/deployment.yaml
@@ -114,6 +114,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/helm/kagent-tools/values.yaml
+++ b/helm/kagent-tools/values.yaml
@@ -131,3 +131,15 @@ otel:
         endpoint: http://host.docker.internal:4317
         timeout: 15
         insecure: true
+
+# Additional volumes and volumeMounts on the tools container. Useful for mounting a
+# kubeconfig (e.g. to point kubectl at an authenticating proxy for per-user RBAC),
+# extra CAs, etc. Standard Kubernetes volume / volumeMount objects.
+extraVolumes: []
+# - name: my-kubeconfig
+#   configMap:
+#     name: my-kubeconfig
+extraVolumeMounts: []
+# - name: my-kubeconfig
+#   mountPath: /etc/kubeconfig
+#   readOnly: true


### PR DESCRIPTION
Adds `extraVolumes` and `extraVolumeMounts` to the `kagent-tools` deployment, appended to the existing `tmp` volume. Both default to `[]`, so there's no change when unset.

### Why
There's currently no way to mount an additional volume on the tools container via values. A concrete use case: mounting a **kubeconfig** so `kubectl` targets an authenticating proxy that scopes tool calls to the *calling user's* RBAC (rather than the tools ServiceAccount) — but this is generically useful for extra CA bundles, config, etc.

### Change
```yaml
# values.yaml
extraVolumes: []
extraVolumeMounts: []
```
Rendered into the deployment via `{{- with .Values.extraVolumes }}` / `{{- with .Values.extraVolumeMounts }}`.

`helm template` verified with a sample configMap volume; no diff when the values are empty.